### PR TITLE
Implement LIFF diagnosis interface

### DIFF
--- a/bot_server/liff/assets/app.js
+++ b/bot_server/liff/assets/app.js
@@ -1,0 +1,315 @@
+const LIFF_ID = window.__LIFF_ID__;
+const BASE_URL = window.__APP_BASE_URL__ || window.location.origin;
+
+const questionsContainer = document.getElementById('questions');
+const progressFill = document.getElementById('progressFill');
+const answeredCountEl = document.getElementById('answeredCount');
+const remainingCountEl = document.getElementById('remainingCount');
+const submitButton = document.getElementById('submitButton');
+const submitContent = document.getElementById('submitContent');
+const shareButton = document.getElementById('shareButton');
+const toastEl = document.getElementById('toast');
+const retryButton = document.getElementById('retryButton');
+const unansweredAlert = document.getElementById('unansweredAlert');
+const resultCard = document.getElementById('resultCard');
+const resultUser = document.getElementById('resultUser');
+const resultCluster = document.getElementById('resultCluster');
+const resultHero = document.getElementById('resultHero');
+
+const DEFAULT_TOTAL = 25;
+let totalQuestions = DEFAULT_TOTAL;
+
+shareButton.disabled = true;
+
+let liffProfile = { userId: 'debug-user', displayName: 'Debug User' };
+let fetchedQuestions = [];
+const answers = new Map();
+let currentSessionId = getSessionParam();
+let isSubmitting = false;
+
+init();
+
+async function init() {
+  try {
+    await ensureLiff();
+  } catch (error) {
+    console.error('LIFF init error', error);
+    showToast('LIFFの初期化に失敗しました。アプリを再起動してください', true);
+  }
+
+  bindFooterActions();
+  await loadQuestions();
+}
+
+function getSessionParam() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('session') || undefined;
+}
+
+async function ensureLiff() {
+  if (window.liff) {
+    await window.liff.init({ liffId: LIFF_ID || undefined });
+    if (!window.liff.isLoggedIn()) {
+      window.liff.login();
+      return new Promise(() => {});
+    }
+    const profile = await window.liff.getProfile();
+    liffProfile = {
+      userId: profile.userId,
+      displayName: profile.displayName || 'LINEユーザー',
+    };
+  } else {
+    console.warn('window.liff not found, using debug profile');
+  }
+}
+
+function bindFooterActions() {
+  submitButton.addEventListener('click', onSubmit);
+  retryButton.addEventListener('click', () => {
+    hideToast();
+    retryButton.classList.add('hidden');
+    loadQuestions();
+  });
+  shareButton.addEventListener('click', () => {
+    if (currentSessionId) {
+      window.location.href = `${BASE_URL}/share/${currentSessionId}`;
+    }
+  });
+}
+
+async function loadQuestions() {
+  questionsContainer.innerHTML = '';
+  questionsContainer.setAttribute('aria-busy', 'true');
+  const loading = document.createElement('div');
+  loading.className = 'question-card';
+  loading.innerHTML = '<p>読み込み中…</p>';
+  questionsContainer.appendChild(loading);
+
+  try {
+    const response = await fetch('/api/diagnosis', {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+    });
+    if (!response.ok) {
+      throw await createFetchError(response);
+    }
+    fetchedQuestions = await response.json();
+    totalQuestions = fetchedQuestions.length || DEFAULT_TOTAL;
+    answers.clear();
+    updateProgress();
+    renderQuestions();
+    questionsContainer.removeAttribute('aria-busy');
+  } catch (error) {
+    console.error('Failed to load questions', error);
+    questionsContainer.innerHTML = '';
+    const card = document.createElement('div');
+    card.className = 'question-card';
+    card.innerHTML = '<p>通信に失敗しました。電波の良い場所で再試行してください。</p>';
+    questionsContainer.appendChild(card);
+    showToast(error.message || '読み込みに失敗しました', true, error.errorId);
+    retryButton.classList.remove('hidden');
+  }
+}
+
+function renderQuestions() {
+  questionsContainer.innerHTML = '';
+  fetchedQuestions.forEach((question, index) => {
+    const card = document.createElement('section');
+    card.className = 'question-card';
+    card.setAttribute('data-question-id', question.question_id);
+
+    const heading = document.createElement('h2');
+    heading.textContent = `${index + 1}. ${question.text}`;
+    card.appendChild(heading);
+
+    const list = document.createElement('div');
+    list.className = 'choices';
+
+    question.choices.forEach((choice) => {
+      const choiceId = `${question.question_id}-${choice.key}`;
+      const wrapper = document.createElement('div');
+      wrapper.className = 'choice';
+
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = question.question_id;
+      input.id = choiceId;
+      input.value = choice.key;
+      input.required = true;
+      input.addEventListener('change', () => handleAnswerChange(question.question_id, choice.key));
+
+      const label = document.createElement('label');
+      label.setAttribute('for', choiceId);
+
+      const title = document.createElement('span');
+      title.className = 'choice-title';
+      title.textContent = choice.label;
+
+      label.appendChild(title);
+
+      if (choice.desc) {
+        const desc = document.createElement('span');
+        desc.className = 'choice-desc';
+        desc.textContent = choice.desc;
+        label.appendChild(desc);
+      }
+
+      wrapper.appendChild(input);
+      wrapper.appendChild(label);
+      list.appendChild(wrapper);
+    });
+
+    card.appendChild(list);
+    questionsContainer.appendChild(card);
+  });
+}
+
+function handleAnswerChange(questionId, choiceKey) {
+  answers.set(questionId, choiceKey);
+  updateProgress();
+}
+
+function updateProgress() {
+  const answeredCount = answers.size;
+  const remaining = Math.max(totalQuestions - answeredCount, 0);
+  answeredCountEl.textContent = answeredCount.toString();
+  remainingCountEl.textContent = remaining.toString();
+  const percent = totalQuestions === 0 ? 0 : (answeredCount / totalQuestions) * 100;
+  progressFill.style.width = `${percent}%`;
+  progressFill.parentElement?.setAttribute('aria-valuenow', answeredCount.toString());
+  updateSubmitState();
+  updateUnansweredAlert();
+}
+
+function updateSubmitState() {
+  const canSubmit = answers.size === totalQuestions && totalQuestions > 0 && !isSubmitting;
+  submitButton.disabled = !canSubmit;
+}
+
+function updateUnansweredAlert() {
+  if (answers.size === totalQuestions && totalQuestions > 0) {
+    unansweredAlert.style.display = 'none';
+    return;
+  }
+  if (!fetchedQuestions.length) {
+    unansweredAlert.style.display = 'none';
+    return;
+  }
+  const missing = fetchedQuestions
+    .map((q, idx) => ({ question: q, index: idx }))
+    .filter(({ question }) => !answers.has(question.question_id))
+    .map(({ index }) => `Q${index + 1}`);
+  if (missing.length) {
+    unansweredAlert.textContent = `未回答：${missing.join('、')}`;
+    unansweredAlert.style.display = 'block';
+  } else {
+    unansweredAlert.style.display = 'none';
+  }
+}
+
+async function onSubmit() {
+  if (answers.size !== totalQuestions || isSubmitting) {
+    updateUnansweredAlert();
+    showToast('未回答の質問があります', true);
+    return;
+  }
+  isSubmitting = true;
+  updateSubmitState();
+  submitContent.innerHTML = '<span class="spinner" aria-hidden="true"></span>';
+
+  try {
+    const payload = {
+      userId: liffProfile.userId,
+      sessionId: currentSessionId,
+      answers: Array.from(answers.entries()).map(([question_id, choice_key]) => ({
+        question_id,
+        choice_key,
+      })),
+    };
+
+    const response = await fetch('/api/diagnosis/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw await createFetchError(response);
+    }
+
+    const result = await response.json();
+    currentSessionId = result.sessionId || currentSessionId;
+    showResult(result);
+    hideToast();
+  } catch (error) {
+    console.error('Submit failed', error);
+    showToast(error.message || '送信に失敗しました', true, error.errorId);
+    retryButton.classList.remove('hidden');
+  } finally {
+    isSubmitting = false;
+    submitContent.textContent = '送信する';
+    updateSubmitState();
+  }
+}
+
+function showResult(result) {
+  questionsContainer.classList.add('hidden');
+  unansweredAlert.style.display = 'none';
+  resultCard.style.display = 'block';
+  submitButton.classList.add('hidden');
+  retryButton.classList.add('hidden');
+  shareButton.classList.remove('hidden');
+
+  const cluster = result.cluster ? `タイプ：${result.cluster}` : '';
+  const hero = result.heroSlug ? `推しキャラ：${result.heroSlug}` : '';
+
+  resultUser.textContent = `${liffProfile.displayName} さん、おつかれさま。`;
+  resultCluster.textContent = cluster;
+  resultHero.textContent = hero;
+
+  if (result.sessionId) {
+    shareButton.disabled = false;
+  } else {
+    shareButton.disabled = true;
+  }
+}
+
+function showToast(message, isError = false, errorId) {
+  toastEl.textContent = errorId ? `${message} (ID: ${errorId})` : message;
+  toastEl.classList.toggle('error', Boolean(isError));
+  toastEl.style.display = 'block';
+  clearTimeout(showToast._timer);
+  showToast._timer = setTimeout(() => {
+    toastEl.style.display = 'none';
+  }, 4000);
+}
+
+function hideToast() {
+  toastEl.style.display = 'none';
+  if (showToast._timer) {
+    clearTimeout(showToast._timer);
+  }
+}
+
+async function createFetchError(response) {
+  let message = `通信に失敗しました (${response.status})`;
+  let errorId;
+  try {
+    const data = await response.json();
+    if (data && data.errorId) {
+      errorId = data.errorId;
+    }
+    if (data && data.message) {
+      message = data.message;
+    }
+  } catch (err) {
+    // ignore JSON parse error
+  }
+  const error = new Error(message);
+  if (errorId) {
+    error.errorId = errorId;
+  }
+  return error;
+}

--- a/bot_server/liff/index.html
+++ b/bot_server/liff/index.html
@@ -1,941 +1,299 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ja">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
-  <meta name="description" content="あなたの個性を診断するチェックツール" />
-  <title>C Lab｜個性チェック</title>
-
-  <style>
-  /* ========== Cbyme Clean Floating UI ========== */
-  :root{
-    /* Brand-ish */
-    --bg-grad-from:#eaf6ff;
-    --bg-grad-to:#f7fffb;
-    --sheet:#ffffff;
-    --ink:#1f2a37;
-    --sub:#70839a;
-    --line:#e7eef6;
-    --accent:#16b1ff;
-    --accent2:#10d6c8;
-    --accent-grad: linear-gradient(180deg, #19c2ff 0%, #10d6c8 100%);
-    --chip:#e9f7ff;
-    --error:#ef4444;
-    --success:#10b981;
-  }
-
-  *{box-sizing:border-box}
-
-  html,body{
-    margin:0;
-    padding:0;
-    scroll-behavior:smooth;
-  }
-
-  body{
-    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Noto Sans JP",Helvetica,Arial,"Hiragino Kaku Gothic ProN","Yu Gothic",Meiryo,sans-serif;
-    color:var(--ink);
-    background:linear-gradient(180deg,var(--bg-grad-from),var(--bg-grad-to)) fixed;
-    -webkit-font-smoothing:antialiased;
-    line-height:1.6;
-  }
-
-  .header{
-    position:sticky;
-    top:0;
-    z-index:20;
-    background:linear-gradient(180deg,rgba(255,255,255,.85),rgba(255,255,255,.55));
-    backdrop-filter:saturate(140%) blur(16px);
-    border-bottom:1px solid rgba(0,0,0,.04);
-  }
-
-  .header-inner{
-    max-width:840px;
-    margin:0 auto;
-    padding:14px 16px;
-    display:flex;
-    align-items:center;
-    gap:10px;
-  }
-
-  .brand-dot{
-    width:26px;
-    height:26px;
-    border-radius:50%;
-    background:conic-gradient(from 180deg,var(--accent),var(--accent2));
-    box-shadow:0 2px 6px rgba(0,0,0,.15);
-  }
-
-  .title{
-    font-weight:800;
-    letter-spacing:.02em;
-    font-size:16px;
-  }
-
-  .wrap{
-    max-width:840px;
-    margin:16px auto 56px;
-    padding:0 14px;
-  }
-
-  .sheet{
-    background:var(--sheet);
-    border:1px solid rgba(31,42,55,.06);
-    border-radius:22px;
-    box-shadow:0 10px 28px rgba(18, 32, 56, .14),0 1px 0 rgba(255,255,255,.6) inset;
-    padding:18px 16px;
-  }
-
-  .section{
-    border-radius:18px;
-    padding:16px 14px;
-    margin:14px 0;
-    border:1px solid var(--line);
-    background:#fff;
-  }
-
-  .section h2{
-    font-size:18px;
-    margin:0 0 8px;
-    color:var(--ink);
-  }
-
-  .section h3{
-    font-size:16px;
-    margin:0 0 4px;
-    color:var(--ink);
-  }
-
-  .qsub,.cap,.note{
-    color:var(--sub);
-    font-size:14px;
-  }
-
-  .required{
-    color:var(--error);
-    font-weight:bold;
-  }
-
-  .row{
-    display:flex;
-    flex-direction:column;
-    gap:12px;
-  }
-
-  .field{
-    display:flex;
-    flex-direction:column;
-    gap:6px;
-  }
-
-  .field.error select,
-  .field.error input[type="text"]{
-    border-color:var(--error);
-    box-shadow:0 0 0 2px rgba(239, 68, 68, .1);
-  }
-
-  .error-message{
-    color:var(--error);
-    font-size:12px;
-    margin-top:4px;
-    display:none;
-  }
-
-  .field.error .error-message{
-    display:block;
-  }
-
-  select,input[type="text"]{
-    height:46px;
-    border-radius:12px;
-    border:1px solid var(--line);
-    background:#fff;
-    color:var(--ink);
-    padding:0 12px;
-    font-size:15px;
-    box-shadow:0 2px 0 rgba(16,214,200,.05) inset;
-    transition:border-color .2s ease, box-shadow .2s ease;
-  }
-
-  select:focus,input[type="text"]:focus{
-    outline:none;
-    border-color:#b9ecff;
-    box-shadow:0 0 0 4px rgba(25,194,255,.14);
-  }
-
-  select:disabled{
-    background:#f8f9fa;
-    color:var(--sub);
-    cursor:not-allowed;
-  }
-
-  .choices{
-    display:flex;
-    flex-direction:column;
-    gap:10px;
-    margin-top:8px;
-  }
-
-  .choice{
-    display:flex;
-    align-items:center;
-    gap:12px;
-    padding:13px 12px;
-    border-radius:14px;
-    border:1px solid var(--line);
-    background:#fff;
-    box-shadow:0 1px 0 rgba(0,0,0,.02);
-    transition:transform .08s ease, box-shadow .2s ease, border-color .2s ease;
-    cursor:pointer;
-  }
-
-  .choice:hover{
-    transform:translateY(-1px);
-    box-shadow:0 8px 18px rgba(18,32,56,.08);
-  }
-
-  .choice:focus-within{
-    border-color:#b9ecff;
-    box-shadow:0 0 0 2px rgba(25,194,255,.14);
-  }
-
-  .choice input[type="radio"]{
-    appearance:none;
-    width:20px;
-    height:20px;
-    border-radius:50%;
-    border:2px solid #9fc9ff;
-    position:relative;
-    flex:0 0 auto;
-    cursor:pointer;
-    transition:border-color .2s ease, background .2s ease;
-  }
-
-  .choice input[type="radio"]:checked{
-    border-color:#2bbfff;
-    background:radial-gradient(circle at 50% 50%, #2bbfff 0 52%, transparent 54%);
-  }
-
-  .choice input[type="radio"]:focus{
-    outline:2px solid #2bbfff;
-    outline-offset:2px;
-  }
-
-  .choice .label{
-    font-size:15px;
-    cursor:pointer;
-  }
-
-  .actions{
-    position:sticky;
-    bottom:0;
-    z-index:15;
-    margin-top:16px;
-  }
-
-  .actions-inner{
-    max-width:840px;
-    margin:0 auto;
-    padding:12px 14px;
-    display:flex;
-    gap:10px;
-    justify-content:center;
-    background:linear-gradient(180deg,rgba(255,255,255,0),rgba(255,255,255,.7));
-    backdrop-filter:blur(10px);
-  }
-
-  .btn{
-    appearance:none;
-    border:none;
-    border-radius:14px;
-    height:52px;
-    padding:0 18px;
-    font-weight:800;
-    letter-spacing:.02em;
-    cursor:pointer;
-    transition:transform .06s ease, filter .2s ease, box-shadow .2s ease;
-    font-size:15px;
-  }
-
-  .btn:disabled{
-    opacity:.6;
-    cursor:not-allowed;
-    transform:none !important;
-  }
-
-  .btn.primary{
-    color:#fff;
-    background:var(--accent-grad);
-    box-shadow:0 8px 18px rgba(25,194,255,.35), inset 0 -2px 0 rgba(0,0,0,.08);
-    min-width:220px;
-  }
-
-  .btn.primary:active:not(:disabled){
-    transform:translateY(1px);
-    filter:saturate(95%);
-  }
-
-  .btn.secondary{
-    background:#fff;
-    border:1px solid var(--line);
-    color:var(--ink);
-    box-shadow:0 2px 8px rgba(0,0,0,.08);
-  }
-
-  .btn.secondary:hover:not(:disabled){
-    background:#f8f9fa;
-  }
-
-  #result .card{
-    margin-top:14px;
-  }
-
-  #result .ttl{
-    font-size:17px;
-    margin:0 0 6px;
-    color:var(--ink);
-  }
-
-  #result .lead{
-    color:var(--sub);
-  }
-
-  #result h4{
-    font-size:15px;
-    margin:14px 0 6px;
-    color:var(--ink);
-  }
-
-  #result .dots{
-    padding-left:18px;
-    margin:6px 0;
-  }
-
-  #result .share{
-    display:flex;
-    gap:10px;
-    margin-top:16px;
-    flex-wrap:wrap;
-  }
-
-  #result .btn.sub{
-    flex:1;
-    height:44px;
-    background:#fff;
-    border:1px solid var(--line);
-    border-radius:12px;
-    min-width:120px;
-  }
-
-  .note{
-    font-size:12px;
-    margin:8px 2px 0;
-  }
-
-  .progress-bar{
-    height:4px;
-    background:var(--line);
-    border-radius:2px;
-    margin:16px 0;
-    overflow:hidden;
-  }
-
-  .progress-fill{
-    height:100%;
-    background:var(--accent-grad);
-    width:0;
-    transition:width .3s ease;
-    border-radius:2px;
-  }
-
-  .loading{
-    display:inline-flex;
-    align-items:center;
-    gap:8px;
-  }
-
-  .spinner{
-    width:16px;
-    height:16px;
-    border:2px solid var(--line);
-    border-top:2px solid var(--accent);
-    border-radius:50%;
-    animation:spin 1s linear infinite;
-  }
-
-  @keyframes spin{ to{transform:rotate(360deg)} }
-
-  .sr-only{
-    position:absolute;
-    width:1px;
-    height:1px;
-    padding:0;
-    margin:-1px;
-    overflow:hidden;
-    clip:rect(0,0,0,0);
-    white-space:nowrap;
-    border:0;
-  }
-
-  @media (min-width:768px){
-    .sheet{padding:22px}
-    .section{padding:18px 16px}
-    .title{font-size:18px}
-    .row{flex-direction:row;flex-wrap:wrap}
-    .field{flex:1;min-width:200px}
-  }
-
-  @media (max-width:480px){
-    .actions-inner{flex-direction:column}
-    .btn{width:100%}
-    #result .share{flex-direction:column}
-    #result .btn.sub{flex:none}
-  }
-
-  @media (prefers-reduced-motion: reduce){
-    *{
-      animation-duration:0.01ms !important;
-      animation-iteration-count:1 !important;
-      transition-duration:0.01ms !important;
-    }
-  }
-
-  /* ===== モーダルウィンドウ ===== */
-  .modal-overlay{
-    position:fixed;
-    top:0;
-    left:0;
-    width:100%;
-    height:100%;
-    background:rgba(31,42,55,.8);
-    backdrop-filter:blur(8px);
-    z-index:1000;
-    display:none;
-    align-items:center;
-    justify-content:center;
-    padding:20px;
-    box-sizing:border-box;
-  }
-  .modal-overlay.show{
-    display:flex;
-    animation:fadeIn .3s ease;
-  }
-  .modal-content{
-    background:var(--sheet);
-    border-radius:24px;
-    box-shadow:0 20px 60px rgba(18,32,56,.3);
-    max-width:600px;
-    max-height:90vh;
-    width:100%;
-    position:relative;
-    overflow:hidden;
-    animation:slideUp .3s ease;
-  }
-  .modal-header{
-    padding:20px 24px 16px;
-    border-bottom:1px solid var(--line);
-    display:flex;
-    align-items:center;
-    justify-content:space-between;
-  }
-  .modal-title{
-    font-size:20px;
-    font-weight:800;
-    color:var(--ink);
-    margin:0;
-  }
-  .modal-close{
-    width:32px;
-    height:32px;
-    border:none;
-    background:none;
-    border-radius:50%;
-    display:flex;
-    align-items:center;
-    justify-content:center;
-    cursor:pointer;
-    color:var(--sub);
-    transition:background .2s ease, color .2s ease;
-  }
-  .modal-close:hover{
-    background:var(--line);
-    color:var(--ink);
-  }
-  .modal-body{
-    padding:24px;
-    max-height:70vh;
-    overflow-y:auto;
-  }
-  .modal-body::-webkit-scrollbar{ width:6px; }
-  .modal-body::-webkit-scrollbar-track{ background:var(--line); border-radius:3px; }
-  .modal-body::-webkit-scrollbar-thumb{ background:var(--sub); border-radius:3px; }
-  .modal-body::-webkit-scrollbar-thumb:hover{ background:var(--accent); }
-
-  @keyframes fadeIn{ from{opacity:0} to{opacity:1} }
-  @keyframes slideUp{
-    from{ opacity:0; transform:translateY(30px) scale(0.95); }
-    to{ opacity:1; transform:translateY(0) scale(1); }
-  }
-
-  @media (max-width:600px){
-    .modal-content{ margin:10px; max-height:85vh; }
-    .modal-header{ padding:16px 20px 12px; }
-    .modal-title{ font-size:18px; }
-    .modal-body{ padding:20px; max-height:65vh; }
-  }
-
-  /* ====== ▼▼▼ ここからトーン刷新の上書き（ポケスリ風・清潔感） ▼▼▼ ====== */
-  :root{
-    --tone-bg:#f5f7f9;
-    --tone-elev:#ffffff;
-    --tone-ink:#1d2430;
-    --tone-ink-soft:#5a6576;
-    --tone-line:#e6ebf1;
-    --tone-accent-from:#71d9a7;
-    --tone-accent-to:#57c3e6;
-    --tone-accent-grad:linear-gradient(180deg,var(--tone-accent-from),var(--tone-accent-to));
-    --tone-chip:#eef8f2;
-  }
-
-  .modal-overlay{
-    background:rgba(17,24,39,.55);
-    backdrop-filter:blur(10px) saturate(120%);
-  }
-  .modal-content{
-    background:var(--tone-elev);
-    border-radius:28px;
-    border:1px solid rgba(0,0,0,.04);
-    box-shadow:0 12px 28px rgba(18,32,56,.10), 0 1px 0 rgba(255,255,255,.8) inset;
-  }
-  .modal-header{
-    padding:22px 24px 14px;
-    border-bottom:1px solid var(--tone-line);
-  }
-  .modal-title{
-    font-size:18px;
-    letter-spacing:.02em;
-    color:var(--tone-ink);
-  }
-  .modal-body{
-    padding:22px 22px 26px;
-    max-width:560px;
-    margin:0 auto;
-    color:var(--tone-ink);
-  }
-
-  #result-content .card{
-    border:1px solid var(--tone-line);
-    border-radius:20px;
-    box-shadow:0 6px 18px rgba(18,32,56,.06);
-    padding:18px 18px 20px;
-    background:#fff;
-    margin-top:14px;
-  }
-  #result-content .ttl{
-    font-weight:800;
-    letter-spacing:.01em;
-    font-size:20px;
-    margin:0 0 4px;
-    color:var(--tone-ink);
-  }
-  #result-content .lead{
-    color:var(--tone-ink-soft);
-    font-size:15px;
-    line-height:1.7;
-  }
-  #result-content h4{
-    margin:18px 0 8px;
-    font-size:14px;
-    font-weight:800;
-    letter-spacing:.02em;
-    color:var(--tone-ink);
-    position:relative;
-  }
-  #result-content h4::after{
-    content:"";
-    display:block;
-    height:1px;
-    background:var(--tone-line);
-    margin-top:8px;
-  }
-  #result-content .dots{ margin:8px 0 2px; padding-left:18px; }
-  #result-content .dots li{ margin:6px 0; color:var(--tone-ink); }
-
-  #result-content .share{
-    display:flex;
-    gap:12px;
-    margin-top:18px;
-    flex-wrap:wrap;
-  }
-  #result-content .btn.sub{
-    flex:1;
-    height:46px;
-    border-radius:12px;
-    border:1px solid var(--tone-line);
-    background:#fff;
-    box-shadow:0 1px 0 rgba(0,0,0,.02);
-    color:var(--tone-ink);
-    font-weight:700;
-    min-width:120px;
-  }
-  #result-content .btn.sub:hover{ background:#f6f9fb; }
-
-  /* ====== ▲▲▲ 上書きここまで ▲▲▲ ====== */
-
-  /* === ▼ ここから指定の追記（既存CSSの最後に統合） ▼ === */
-  /* ここまで既存CSS ... */
-
-  /* === 診断結果UI トーン調整 === */
-  .btn.primary{
-    background:var(--tone-accent-grad);
-    box-shadow:0 8px 16px rgba(87,195,230,.25);
-  }
-  .progress-bar{ height:3px; background:#edf2f6; }
-  .progress-fill{ background:var(--tone-accent-grad); }
-
-  .modal-close:hover{ background:#f2f6fa; color:var(--tone-ink); }
-
-  @media (max-width:480px){
-    .modal-content{ border-radius:22px; }
-    .modal-body{ padding:18px 16px 22px; }
-    #result-content .card{ padding:16px; }
-    #result-content .ttl{ font-size:19px; }
-  }
-
-  .badge{
-    display:inline-block;
-    padding:6px 10px;
-    border-radius:999px;
-    background:var(--tone-chip);
-    border:1px solid #daf0e3;
-    font-size:13px;
-  }
-  /* === ▲ 追記ここまで ▲ === */
-  </style>
-</head>
-
-<body>
-  <div class="header">
-    <div class="header-inner">
-      <div class="brand-dot" aria-hidden="true"></div>
-      <h1 class="title">C Lab｜個性チェック</h1>
-    </div>
-  </div>
-
-  <div class="wrap">
-    <div class="sheet">
-      <div id="status" class="qsub" style="text-align:center;margin-bottom:8px">
-        <span class="loading">
-          <span class="spinner" aria-hidden="true"></span>
-          読み込み中…
-        </span>
-      </div>
-
-      <div class="progress-bar" aria-label="進捗">
-        <div class="progress-fill" id="progress"></div>
-      </div>
-
-      <form id="personalityForm" novalidate>
-        <!-- プロフィール -->
-        <section class="section" id="profile">
-          <h2>プロフィール</h2>
-          <div class="row">
-            <div class="field" id="gender-field">
-              <label for="gender" class="cap">性別 <span class="required">*</span></label>
-              <select id="gender" required aria-describedby="gender-error">
-                <option value="">選択してください</option>
-                <option value="male">男性</option>
-                <option value="female">女性</option>
-                <option value="other">その他</option>
-              </select>
-              <div class="error-message" id="gender-error">性別を選択してください</div>
-            </div>
-
-            <div class="field" id="age-field">
-              <label for="age" class="cap">年齢 <span class="required">*</span></label>
-              <select id="age" required aria-describedby="age-error">
-                <option value="">選択してください</option>
-                <!-- 12〜35 は下のJSで自動挿入 -->
-              </select>
-              <div class="error-message" id="age-error">年齢を選択してください</div>
-            </div>
-
-            <div class="field">
-              <label for="mbti" class="cap">MBTI（任意）</label>
-              <select id="mbti" aria-describedby="mbti-help">
-                <option value="">未回答</option>
-                <option value="INTJ">INTJ：建築家</option><option value="INTP">INTP：論理学者</option>
-                <option value="ENTJ">ENTJ：指揮官</option><option value="ENTP">ENTP：討論者</option>
-                <option value="INFJ">INFJ：提唱者</option><option value="INFP">INFP：仲介者</option>
-                <option value="ENFJ">ENFJ：主人公</option><option value="ENFP">ENFP：運動家</option>
-                <option value="ISTJ">ISTJ：管理者</option><option value="ISFJ">ISFJ：擁護者</option>
-                <option value="ESTJ">ESTJ：幹部</option><option value="ESFJ">ESFJ：領事</option>
-                <option value="ISTP">ISTP：巨匠</option><option value="ISFP">ISFP：冒険家</option>
-                <option value="ESTP">ESTP：起業家</option><option value="ESFP">ESFP：エンターテイナー</option>
-              </select>
-              <div id="mbti-help" class="note">分からない場合は「未回答」のままで大丈夫です</div>
-            </div>
-          </div>
-        </section>
-
-        <!-- Q1 -->
-        <section class="section">
-          <fieldset style="border:none;padding:0;margin:0">
-            <legend><h3>1. なにかに取りかかるとき、近いのは？🏃‍♂️</h3></legend>
-            <div class="choices" role="radiogroup" aria-labelledby="q1-legend">
-              <label class="choice">
-                <input type="radio" name="q1" value="A" id="q1-a">
-                <span class="label">A. とりあえず始めて、やりながら直す派</span>
-              </label>
-              <label class="choice">
-                <input type="radio" name="q1" value="B" id="q1-b">
-                <span class="label">B. まず全体を考えてから始める派</span>
-              </label>
-            </div>
-          </fieldset>
-        </section>
-
-        <!-- Q2 -->
-        <section class="section">
-          <fieldset style="border:none;padding:0;margin:0">
-            <legend><h3>2. なやんだとき、何基準で決める？💭</h3></legend>
-            <div class="choices" role="radiogroup">
-              <label class="choice">
-                <input type="radio" name="q2" value="A" id="q2-a">
-                <span class="label">A. なんとなくの直感とかノリで決める</span>
-              </label>
-              <label class="choice">
-                <input type="radio" name="q2" value="B" id="q2-b">
-                <span class="label">B. 理由とかデータを見て決める</span>
-              </label>
-            </div>
-          </fieldset>
-        </section>
-
-        <!-- Q3（モチベーション：プルダウン×3） -->
-        <section class="section">
-          <h3>3. 「よし、がんばろう！」と思えるのは？🔥</h3>
-          <p class="qsub">複数選択OK／できれば順位付けしてください</p>
-
-          <div class="row">
-            <!-- 1位 -->
-            <div class="field">
-              <label for="mot1" class="cap">第1位</label>
-              <select id="mot1" aria-describedby="mot-help">
-                <option value="">未選択</option>
-                <option value="がんばって結果を出したとき／達成したとき">がんばって結果を出したとき／達成したとき</option>
-                <option value="人にほめられたり「いいね！」って言われたとき">人にほめられたり「いいね！」って言われたとき</option>
-                <option value="人の役に立てたとき">人の役に立てたとき</option>
-                <option value="安心できる場所や環境にいるとき">安心できる場所や環境にいるとき</option>
-                <option value="新しいことを知ったり学べたとき">新しいことを知ったり学べたとき</option>
-                <option value="自分のやり方で自由にできるとき">自分のやり方で自由にできるとき</option>
-                <option value="友だちや仲間と一緒にやっているとき">友だちや仲間と一緒にやっているとき</option>
-                <option value="少しでも自分が成長したと感じたとき">少しでも自分が成長したと感じたとき</option>
-                <option value="おこづかいやお金がもらえたとき">おこづかいやお金がもらえたとき</option>
-                <option value="リーダーになれたり、みんなから頼られたとき">リーダーになれたり、みんなから頼られたとき</option>
-                <option value="楽しいことやワクワクすることができたとき">楽しいことやワクワクすることができたとき</option>
-                <option value="むずかしいことにチャレンジできたとき">むずかしいことにチャレンジできたとき</option>
-                <option value="人を動かしたり、大きな影響をあたえられたとき">人を動かしたり、大きな影響をあたえられたとき</option>
-              </select>
-            </div>
-
-            <!-- 2位 -->
-            <div class="field">
-              <label for="mot2" class="cap">第2位（任意）</label>
-              <select id="mot2">
-                <option value="">未選択</option>
-                <option value="がんばって結果を出したとき／達成したとき">がんばって結果を出したとき／達成したとき</option>
-                <option value="人にほめられたり「いいね！」って言われたとき">人にほめられたり「いいね！」って言われたとき</option>
-                <option value="人の役に立てたとき">人の役に立てたとき</option>
-                <option value="安心できる場所や環境にいるとき">安心できる場所や環境にいるとき</option>
-                <option value="新しいことを知ったり学べたとき">新しいことを知ったり学べたとき</option>
-                <option value="自分のやり方で自由にできるとき">自分のやり方で自由にできるとき</option>
-                <option value="友だちや仲間と一緒にやっているとき">友だちや仲間と一緒にやっているとき</option>
-                <option value="少しでも自分が成長したと感じたとき">少しでも自分が成長したと感じたとき</option>
-                <option value="おこづかいやお金がもらえたとき">おこづかいやお金がもらえたとき</option>
-                <option value="リーダーになれたり、みんなから頼られたとき">リーダーになれたり、みんなから頼られたとき</option>
-                <option value="楽しいことやワクワクすることができたとき">楽しいことやワクワクすることができたとき</option>
-                <option value="むずかしいことにチャレンジできたとき">むずかしいことにチャレンジできたとき</option>
-                <option value="人を動かしたり、大きな影響をあたえられたとき">人を動かしたり、大きな影響をあたえられたとき</option>
-              </select>
-            </div>
-
-            <!-- 3位 -->
-            <div class="field">
-              <label for="mot3" class="cap">第3位（任意）</label>
-              <select id="mot3">
-                <option value="">未選択</option>
-                <option value="がんばって結果を出したとき／達成したとき">がんばって結果を出したとき／達成したとき</option>
-                <option value="人にほめられたり「いいね！」って言われたとき">人にほめられたり「いいね！」って言われたとき</option>
-                <option value="人の役に立てたとき">人の役に立てたとき</option>
-                <option value="安心できる場所や環境にいるとき">安心できる場所や環境にいるとき</option>
-                <option value="新しいことを知ったり学べたとき">新しいことを知ったり学べたとき</option>
-                <option value="自分のやり方で自由にできるとき">自分のやり方で自由にできるとき</option>
-                <option value="友だちや仲間と一緒にやっているとき">友だちや仲間と一緒にやっているとき</option>
-                <option value="少しでも自分が成長したと感じたとき">少しでも自分が成長したと感じたとき</option>
-                <option value="おこづかいやお金がもらえたとき">おこづかいやお金がもらえたとき</option>
-                <option value="リーダーになれたり、みんなから頼られたとき">リーダーになれたり、みんなから頼られたとき</option>
-                <option value="楽しいことやワクワクすることができたとき">楽しいことやワクワクすることができたとき</option>
-                <option value="むずかしいことにチャレンジできたとき">むずかしいことにチャレンジできたとき</option>
-                <option value="人を動かしたり、大きな影響をあたえられたとき">人を動かしたり、大きな影響をあたえられたとき</option>
-              </select>
-            </div>
-          </div>
-
-          <p class="note" id="mot-help">※ 同じ項目は重複できません。選ばない場合は「未選択」のままでOK。</p>
-
-          <!-- app.js が読む hidden チェックボックス（自動同期） -->
-          <div id="q3-hidden" style="display:none">
-            <input type="checkbox" name="q3" value="がんばって結果を出したとき／達成したとき">
-            <input type="checkbox" name="q3" value="人にほめられたり「いいね！」って言われたとき">
-            <input type="checkbox" name="q3" value="人の役に立てたとき">
-            <input type="checkbox" name="q3" value="安心できる場所や環境にいるとき">
-            <input type="checkbox" name="q3" value="新しいことを知ったり学べたとき">
-            <input type="checkbox" name="q3" value="自分のやり方で自由にできるとき">
-            <input type="checkbox" name="q3" value="友だちや仲間と一緒にやっているとき">
-            <input type="checkbox" name="q3" value="少しでも自分が成長したと感じたとき">
-            <input type="checkbox" name="q3" value="おこづかいやお金がもらえたとき">
-            <input type="checkbox" name="q3" value="リーダーになれたり、みんなから頼られたとき">
-            <input type="checkbox" name="q3" value="楽しいことやワクワクすることができたとき">
-            <input type="checkbox" name="q3" value="むずかしいことにチャレンジできたとき">
-            <input type="checkbox" name="q3" value="人を動かしたり、大きな影響をあたえられたとき">
-          </div>
-        </section>
-
-        <!-- Q4 -->
-        <section class="section">
-          <fieldset style="border:none;padding:0;margin:0">
-            <legend><h3>4. どちらの方がしんどい？😓</h3></legend>
-            <div class="choices" role="radiogroup">
-              <label class="choice">
-                <input type="radio" name="q4" value="A" id="q4-a">
-                <span class="label">A. ずっと細かく口出しされる方がしんどい</span>
-              </label>
-              <label class="choice">
-                <input type="radio" name="q4" value="B" id="q4-b">
-                <span class="label">B. ほったらかしで丸投げされる方がしんどい</span>
-              </label>
-            </div>
-          </fieldset>
-        </section>
-
-        <!-- Q5 -->
-        <section class="section">
-          <fieldset style="border:none;padding:0;margin:0">
-            <legend><h3>5. 感情が動いた時に近いのはどっち？🫀</h3></legend>
-            <div class="choices" role="radiogroup">
-              <label class="choice">
-                <input type="radio" name="q5" value="A" id="q5-a">
-                <span class="label">A. すぐ顔とか言葉に出ちゃう</span>
-              </label>
-              <label class="choice">
-                <input type="radio" name="q5" value="B" id="q5-b">
-                <span class="label">B. 顔とか態度には出さないけど思うところはある</span>
-              </label>
-            </div>
-          </fieldset>
-        </section>
-
-        <!-- Q6 -->
-        <section class="section">
-          <fieldset style="border:none;padding:0;margin:0">
-            <legend><h3>6. 一緒にいてラクなのは？😌</h3></legend>
-            <div class="choices" role="radiogroup">
-              <label class="choice">
-                <input type="radio" name="q6" value="A" id="q6-a">
-                <span class="label">A. 何でもズバッと言えるチーム</span>
-              </label>
-              <label class="choice">
-                <input type="radio" name="q6" value="B" id="q6-b">
-                <span class="label">B. 空気を大事にして、まったりなチーム</span>
-              </label>
-            </div>
-          </fieldset>
-        </section>
-
-        <!-- Q7 -->
-        <section class="section">
-          <fieldset style="border:none;padding:0;margin:0">
-            <legend><h3>7. あなたが班やチームで自然に多いのはどっち？🤝</h3></legend>
-            <div class="choices" role="radiogroup">
-              <label class="choice">
-                <input type="radio" name="q7" value="A" id="q7-a">
-                <span class="label">A. みんなを引っ張るリーダータイプ</span>
-              </label>
-              <label class="choice">
-                <input type="radio" name="q7" value="B" id="q7-b">
-                <span class="label">B. サポートして支えるタイプ</span>
-              </label>
-            </div>
-          </fieldset>
-        </section>
-
-        <!-- Q8 -->
-        <section class="section">
-          <fieldset style="border:none;padding:0;margin:0">
-            <legend><h3>8. じぶんの理想に近いのは？💫</h3></legend>
-            <div class="choices" role="radiogroup">
-              <label class="choice">
-                <input type="radio" name="q8" value="A" id="q8-a">
-                <span class="label">A. 一つのことを極めたい</span>
-              </label>
-              <label class="choice">
-                <input type="radio" name="q8" value="B" id="q8-b">
-                <span class="label">B. いろんなことに同時にチャレンジしたい</span>
-              </label>
-            </div>
-          </fieldset>
-        </section>
-      </form>
-
-      <!-- 結果表示エリア -->
-      <div id="result" style="display:none;"></div>
-    </div>
-  </div>
-
-  <!-- アクション -->
-  <div class="actions">
-    <div class="actions-inner">
-      <button type="button" id="run" class="btn primary">診断する</button>
-    </div>
-  </div>
-
-  <!-- 診断結果モーダル -->
-  <div id="result-modal" class="modal-overlay">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h2 class="modal-title">🎉 診断結果</h2>
-        <button type="button" class="modal-close" id="close-modal" aria-label="閉じる">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="18" y1="6" x2="6" y2="18"></line>
-            <line x1="6" y1="6" x2="18" y2="18"></line>
-          </svg>
-        </button>
-      </div>
-      <div class="modal-body" id="result-content">
-        <!-- 診断結果がここに表示される -->
-      </div>
-    </div>
-  </div>
-
-  <!-- LIFF SDK -->
-  <script charset="utf-8" src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>
-  <!-- アプリJS -->
-  <script src="app.js"></script>
-
-  <script>
-    // 年齢プルダウンを自動生成（12〜50歳）
-    document.addEventListener('DOMContentLoaded', () => {
-      const ageSelect = document.getElementById('age');
-      if (ageSelect) {
-        for (let i = 12; i <= 50; i++) {
-          const option = document.createElement('option');
-          option.value = i;
-          option.textContent = `${i}歳`;
-          ageSelect.appendChild(option);
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+    <title>働き方診断</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <style>
+      :root {
+        --bg: #0b0b0f;
+        --fg: #f5f5f5;
+        --accent: #00d1ff;
+        --muted: #8aa0b2;
+        --danger: #ff4d6d;
+        --card: #0e1217;
+        --ring: 0 0 0 2px var(--accent);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        padding: 0;
+        margin: 0;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        line-height: 1.6;
+      }
+      body {
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+      a {
+        color: inherit;
+      }
+      button {
+        font-family: inherit;
+      }
+      .app {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        position: relative;
+      }
+      header {
+        padding: 24px 20px 12px;
+      }
+      .title {
+        font-size: 1.5rem;
+        font-weight: 700;
+        margin: 0 0 8px;
+      }
+      .subtitle {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+      .progress-bar {
+        height: 8px;
+        background: #14202b;
+        border-radius: 999px;
+        overflow: hidden;
+        margin: 0 20px 12px;
+      }
+      .progress-fill {
+        height: 100%;
+        width: 0;
+        background: var(--accent);
+        transition: width 0.2s ease;
+      }
+      .status {
+        margin: 0 20px 12px;
+        font-size: 0.9rem;
+        color: var(--muted);
+      }
+      .status strong {
+        color: var(--fg);
+      }
+      .alert {
+        margin: 0 20px 16px;
+        padding: 12px 16px;
+        border-radius: 12px;
+        background: rgba(255, 77, 109, 0.12);
+        color: var(--danger);
+        font-size: 0.9rem;
+        display: none;
+      }
+      .questions {
+        flex: 1;
+        overflow-y: auto;
+        padding: 0 20px 120px;
+      }
+      .question-card {
+        background: var(--card);
+        border-radius: 16px;
+        padding: 20px;
+        margin-bottom: 16px;
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+      }
+      .question-card h2 {
+        font-size: 1.05rem;
+        margin: 0 0 16px;
+      }
+      .choices {
+        display: grid;
+        gap: 12px;
+      }
+      .choice {
+        position: relative;
+      }
+      .choice input {
+        position: absolute;
+        opacity: 0;
+      }
+      .choice label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        border-radius: 14px;
+        padding: 14px 16px;
+        background: rgba(255, 255, 255, 0.02);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        min-height: 52px;
+        cursor: pointer;
+        transition: border-color 0.2s ease, background 0.2s ease, transform 0.15s ease;
+      }
+      .choice label:hover {
+        background: rgba(0, 209, 255, 0.12);
+      }
+      .choice input:focus-visible + label {
+        outline: none;
+        box-shadow: var(--ring);
+      }
+      .choice input:checked + label {
+        border-color: var(--accent);
+        background: rgba(0, 209, 255, 0.18);
+      }
+      .choice-title {
+        font-weight: 600;
+        font-size: 1rem;
+      }
+      .choice-desc {
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+      .footer {
+        position: sticky;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        padding: 16px 20px 24px;
+        background: linear-gradient(180deg, rgba(11, 11, 15, 0.2) 0%, var(--bg) 40%);
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .footer button {
+        width: 100%;
+        padding: 14px;
+        border: none;
+        border-radius: 14px;
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--bg);
+        background: var(--accent);
+        cursor: pointer;
+        transition: opacity 0.2s ease, transform 0.2s ease;
+      }
+      .footer button:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+      .footer button:focus-visible {
+        outline: none;
+        box-shadow: var(--ring);
+      }
+      .footer button:not(:disabled):active {
+        transform: translateY(1px);
+      }
+      .footer .secondary {
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid rgba(0, 209, 255, 0.6);
+      }
+      .footer .secondary:disabled {
+        opacity: 0.4;
+        border-color: rgba(255, 255, 255, 0.1);
+      }
+      .toast {
+        position: fixed;
+        left: 50%;
+        bottom: 96px;
+        transform: translateX(-50%);
+        background: rgba(14, 18, 23, 0.92);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 14px;
+        padding: 14px 18px;
+        color: var(--fg);
+        font-size: 0.95rem;
+        display: none;
+        max-width: calc(100% - 40px);
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+      }
+      .toast.error {
+        border-color: rgba(255, 77, 109, 0.5);
+        color: var(--danger);
+      }
+      .hidden {
+        display: none !important;
+      }
+      .result-card {
+        text-align: center;
+        padding: 32px 20px 24px;
+        display: none;
+      }
+      .result-card h1 {
+        font-size: 1.6rem;
+        margin-bottom: 12px;
+      }
+      .result-card p {
+        margin: 6px 0;
+        color: var(--muted);
+      }
+      .spinner {
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        border: 3px solid rgba(255, 255, 255, 0.25);
+        border-top-color: var(--bg);
+        animation: spin 0.8s linear infinite;
+        margin: 0 auto;
+      }
+      .btn-content {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
         }
       }
-    });
-  </script>
-</body>
+      @media (min-width: 600px) {
+        body {
+          align-items: center;
+        }
+        .app {
+          width: min(560px, 100%);
+          margin: 0 auto;
+          border-radius: 24px;
+          background: linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0) 100%);
+        }
+        .footer {
+          border-bottom-left-radius: 24px;
+          border-bottom-right-radius: 24px;
+        }
+      }
+    </style>
+    <script src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>
+    <script>
+      window.__LIFF_ID__ = '';
+      window.__APP_BASE_URL__ = '';
+    </script>
+  </head>
+  <body>
+    <div class="app">
+      <header>
+        <h1 class="title">25問で、あなたの働き方を可視化</h1>
+        <p class="subtitle">あと<span id="remainingCount">25</span>問</p>
+      </header>
+      <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="25" aria-valuenow="0">
+        <div class="progress-fill" id="progressFill"></div>
+      </div>
+      <p class="status"><strong id="answeredCount">0</strong>/25 件回答済み</p>
+      <div class="alert" id="unansweredAlert" role="status"></div>
+      <main class="questions" id="questions"></main>
+      <section class="result-card" id="resultCard">
+        <h1>診断が完了したよ</h1>
+        <p id="resultUser"></p>
+        <p id="resultCluster"></p>
+        <p id="resultHero"></p>
+      </section>
+      <div class="toast" id="toast"></div>
+      <footer class="footer">
+        <button type="button" class="secondary hidden" id="retryButton">もう一度試す</button>
+        <button type="button" id="submitButton" disabled>
+          <span class="btn-content" id="submitContent">送信する</span>
+        </button>
+        <button type="button" class="hidden" id="shareButton">結果をシェア</button>
+      </footer>
+    </div>
+    <script type="module" src="./assets/app.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the LIFF diagnosis page with dark-mode card layout, progress bar, and footer actions
- add a vanilla JS module to load questions via the diagnosis API, track answers, and submit results
- handle LIFF initialization, result display, and error toasts with retry and share options

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d77a54f3648325a9cc18cdc235e2bc